### PR TITLE
Extend configurable options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ This example would enable the simple formatting plugin that provides functionali
 
 Please note that you need to load the plugin JavaScript files you want to use manually.
 
+Hallo has got more options you set when instantiating. See the hallo.coffee file for further documentation.
+
 ## Plugins
 
 * halloformat - Adds Bold, Italic, StrikeThrough and Underline support to the toolbar. (Pick with options: "formattings": ["bold", "italic", "strikeThough", "underline"])

--- a/hallo.coffee
+++ b/hallo.coffee
@@ -20,6 +20,28 @@
     # Hallo, then a floating editing toolbar will be rendered above
     # the editable contents when an area is active.
     #
+    # ## Options
+    #
+    # Change from floating mode to relative positioning with using
+    # the offset to position the toolbar where you want it:
+    #
+    #    jQuery('selector').hallo({
+    #       floating: true,
+    #       offset: {
+    #         'x' : 0,
+    #         'y' : 0
+    #       }
+    #    });
+    #
+    # Force the toolbar to be shown at all times when a contenteditable
+    # element is focused:
+    #
+    #    jQuery('selector').hallo({
+    #       showalways: true
+    #    });
+    #
+    # showalways is false by default
+    #
     # ## Events
     #
     # The Hallo editor provides several jQuery events that web
@@ -62,6 +84,9 @@
         options:
             editable: true
             plugins: {}
+            floating: true
+            offset: {x:0,y:0}
+            showalways: false
             activated: ->
             deactivated: ->
             selected: ->
@@ -149,7 +174,16 @@
 
         _getToolbarPosition: (event, selection) ->
             if event.originalEvent instanceof MouseEvent
-                return [event.pageX, event.pageY]
+                if @options.floating
+                    return [event.pageX, event.pageY]
+                else
+                    if $(event.target).attr('contenteditable') == "true"
+                        containerElement = $(event.target)
+                    else
+                        containerElement = $(event.target).parent('[contenteditable]').first()
+
+                    containerPosition = containerElement.position()
+                    return [containerPosition.left - @options.offset.x, containerPosition.top - @options.offset.y]
 
             range = selection.getRangeAt 0
             tmpSpan = jQuery "<span/>"
@@ -178,7 +212,8 @@
                 widget.toolbar.show()
 
             @element.bind "hallounselected", (event, data) ->
-                data.editable.toolbar.hide()
+                if not that.options.showalways
+                    data.editable.toolbar.hide()
 
         _checkModified: (event) ->
             widget = event.data


### PR DESCRIPTION
Hello bergie

This is one of the pull requests David Buchmann announced to you. 

I added an option whether the Toolbar should be floating or not. 
If you set floating to "false" you can position the toolbar with the offset values. 
When floating is set to "true", the offset values are simply ignored.

This closes #12 and #13
