### PR TITLE
Added missing variable

### DIFF
--- a/hallo.coffee
+++ b/hallo.coffee
@@ -196,6 +196,7 @@
             position
 
         _prepareToolbar: ->
+            that = @
             @toolbar = jQuery('<div></div>').hide()
             @toolbar.css "position", "absolute"
             @toolbar.css "top", @element.offset().top - 20


### PR DESCRIPTION
There was a variable missing in the last pull request, sorry about that.
The "that" variable was missing. The following line is causing an error without it.

``` javascript
if not that.options.showalways
```
