### PR TITLE
Fixing an OS X issue with the Cakefile

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -35,7 +35,7 @@ task 'build', 'generate unified JavaScript file for whole Hallo', ->
   console.log version
   series [
     (sh "cp -R src tmp")
-    (sh "sed -i 's/{{ VERSION }}/#{version}/' '#{__dirname}/tmp/hallo.coffee'")
+    (sh "sed -ie 's/{{ VERSION }}/#{version}/' '#{__dirname}/tmp/hallo.coffee'")
     (sh "coffee -o examples -j hallo.js -c `find tmp -type f -name '*.coffee'`")
     (sh "rm -r tmp")
   ]
@@ -45,7 +45,7 @@ task 'min', 'minify the generated JavaScript file', ->
   console.log version
   series [
     (sh "cp -R src tmp")
-    (sh "sed -i 's/{{ VERSION }}/#{version}/' '#{__dirname}/tmp/hallo.coffee'")
+    (sh "sed -ie 's/{{ VERSION }}/#{version}/' '#{__dirname}/tmp/hallo.coffee'")
     (sh "coffee -o examples -j hallo.js -c `find tmp -type f -name '*.coffee'`")
     (sh "uglifyjs examples/hallo.js > examples/hallo-min.js")
     (sh "rm -r tmp")


### PR DESCRIPTION
Fixes an issue on OS X that can cause the sed command to fail; untested on other OSes, but should not affect them. If cloned under the User dir, and the username starts with 'k', it can cause this error message due to regex evaluation:

``` bash
1.0.1dev
Executing cp -R src tmp
Executing sed -i 's/{{ VERSION }}/1.0.1dev/' '/Users/kevinb/Sites/workspace/thotter/web/hallo/tmp/hallo.coffee'
{ [Error: Command failed: sed: 1: "/Users/kevinb/Sites/wor ...": invalid command code k
] killed: false, code: 1, signal: null }
sed: 1: "/Users/kevinb/Sites/wor ...": invalid command code k
```
