### PR TITLE
Image Plugin: Fix double wrapping of toolbar button.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 docs/
 node_modules/
 docs_tmp/

--- a/examples/hallo.js
+++ b/examples/hallo.js
@@ -1628,7 +1628,6 @@ http://hallojs.org
         jQuery(this.options.editable.element).delegate("img", "click", function(event) {
           return widget._openDialog();
         });
-        buttonset.buttonset();
         toolbar.append(buttonset);
         this.options.dialog.dialog(this.options.dialogOpts);
         return this._handleTabs();

--- a/src/plugins/image.coffee
+++ b/src/plugins/image.coffee
@@ -126,7 +126,6 @@
       jQuery(@options.editable.element).delegate "img", "click", (event) ->
         widget._openDialog()
 
-      buttonset.buttonset()
       toolbar.append buttonset
 
       @options.dialog.dialog(@options.dialogOpts)


### PR DESCRIPTION
The button was double wrapped in `<span class="ui-button-text">`. That caused the button to have double padding, making it larger than the other buttons in the toolbar.
