### PR TITLE
Toolbar width no longer limited to editable content width

### DIFF
--- a/src/toolbar/fixed.coffee
+++ b/src/toolbar/fixed.coffee
@@ -23,18 +23,6 @@
       jQuery(window).resize (event) =>
         @setPosition()
 
-      # Make sure the toolbar has not got the full width of the editable
-      # element when floating is set to true
-      if @options.parentElement is 'body'
-        el = jQuery(@element)
-        widthToAdd = parseFloat el.css('padding-left')
-        widthToAdd += parseFloat el.css('padding-right')
-        widthToAdd += parseFloat el.css('border-left-width')
-        widthToAdd += parseFloat el.css('border-right-width')
-        widthToAdd += (parseFloat el.css('outline-width')) * 2
-        widthToAdd += (parseFloat el.css('outline-offset')) * 2
-        jQuery(@toolbar).css "width", el.width() + widthToAdd
-
     _getPosition: (event, selection) ->
       return unless event
       width = parseFloat @element.css 'outline-width'


### PR DESCRIPTION
When editing content that is in a narrow column the toolbar is wrapped to the same width as the content. This default is impossible to change without hacking up hallo since the width is set to the "style" attribute of hallotoolbar.

Solution: Keep it minimal by not messing with the width of the toolbar. =)
