### PR TITLE
Display Hallo toolbar correctly when page has a global margin set

### DIFF
--- a/src/toolbar/contextual.coffee
+++ b/src/toolbar/contextual.coffee
@@ -72,8 +72,8 @@
         else
           top_offset = selectionRect.bottom + 10
 
-        top = $(window).scrollTop() + top_offset
-        left = $(window).scrollLeft() + selectionRect.left
+        top = jQuery(window).scrollTop() + top_offset
+        left = jQuery(window).scrollLeft() + selectionRect.left
       else
         if this.options.positionAbove
           top_offset = -10 - toolbar_height_offset
@@ -81,6 +81,11 @@
           top_offset = 20
         top = position.top + top_offset
         left = position.left - @toolbar.outerWidth() / 2 + 30
+
+      # if the body has a "margin" set which pushes all content down/right, we also
+      # need to apply it here.
+      top -= jQuery('body').offset().top
+      left -= jQuery('body').offset().left
       @toolbar.css 'top', top
       @toolbar.css 'left', left
 

--- a/src/toolbar/fixed.coffee
+++ b/src/toolbar/fixed.coffee
@@ -59,8 +59,11 @@
     setPosition: ->
       return unless @options.parentElement is 'body'
       @toolbar.css 'position', 'absolute'
-      @toolbar.css 'top', @element.offset().top - @toolbar.outerHeight()
-      @toolbar.css 'left', @element.offset().left + 10
+
+      # if the body has a "margin" set which pushes all content down/right, we also
+      # need to apply it here.
+      @toolbar.css 'top', @element.offset().top - @toolbar.outerHeight() - jQuery('body').offset().top
+      @toolbar.css 'left', @element.offset().left - jQuery('body').offset().left + 10
 
     _updatePosition: (position) ->
       return


### PR DESCRIPTION
If the body has a margin-top or margin-left set, the hallo controls appear
too far at the bottom or too far at the right without this change.

With this change, the location is correct.
