### PR TITLE
Revert "[BUGFIX] Display Hallo toolbar correctly when page has a global margin set"

### DIFF
--- a/src/toolbar/contextual.coffee
+++ b/src/toolbar/contextual.coffee
@@ -81,11 +81,6 @@
           top_offset = 20
         top = position.top + top_offset
         left = position.left - @toolbar.outerWidth() / 2 + 30
-
-      # if the body has a "margin" set which pushes all content down/right, we also
-      # need to apply it here.
-      top -= jQuery('body').offset().top
-      left -= jQuery('body').offset().left
       @toolbar.css 'top', top
       @toolbar.css 'left', left
 

--- a/src/toolbar/fixed.coffee
+++ b/src/toolbar/fixed.coffee
@@ -59,11 +59,8 @@
     setPosition: ->
       return unless @options.parentElement is 'body'
       @toolbar.css 'position', 'absolute'
-
-      # if the body has a "margin" set which pushes all content down/right, we also
-      # need to apply it here.
-      @toolbar.css 'top', @element.offset().top - @toolbar.outerHeight() - jQuery('body').offset().top
-      @toolbar.css 'left', @element.offset().left - jQuery('body').offset().left + 10
+      @toolbar.css 'top', @element.offset().top - @toolbar.outerHeight()
+      @toolbar.css 'left', @element.offset().left + 10
 
     _updatePosition: (position) ->
       return


### PR DESCRIPTION
the real root-cause of the problem was introduced by having a "position:relative"
style on the "body"-Tag (due to the use of the Zurb Foundation framework).
Removing this style, the positioning problem is solved.

This reverts commit 34e4a6fef0213b9b0164200179358268ab1de23c.

Sorry for the hazzle!
