### PR TITLE
fix whitespace preventing placeholder to show up

### DIFF
--- a/src/hallo.coffee
+++ b/src/hallo.coffee
@@ -174,7 +174,7 @@ http://hallojs.org
 
       @element.attr "contentEditable", true
 
-      unless @element.html()
+      unless @element.html().trim()
         @element.html this.options.placeholder
         @element.css
           'min-width': @element.innerWidth()


### PR DESCRIPTION
```
<p id="test">
</p>

<p id="test"></p>

$('#test').hallo({ placeholder: 'test' });
```

The placeholder will only show up in the second case due to the sneaky newline.
