### PR TITLE
Clean HTML plugin ignores options

### DIFF
--- a/src/plugins/cleanhtml.coffee
+++ b/src/plugins/cleanhtml.coffee
@@ -47,7 +47,7 @@
       editor = this.element
       
       # bind paste handler on first call
-      editor.bind 'paste', this, (event) ->
+      editor.bind 'paste', this, (event) =>
        
         # TODO: find out why this check always fails when placed directly
         # after jQuery.htmlClean check
@@ -65,7 +65,7 @@
         lastContent = editor.html()
         editor.html ''
         
-        setTimeout ->
+        setTimeout =>
           
           pasted = editor.html()
           cleanPasted = jQuery.htmlClean pasted, @options


### PR DESCRIPTION
The options for the cleanhtml plugin refer to current object but that isn't in scope. So I switched the function type to bind this on the callbacks so it was still in scope.
