### PR TITLE
Fixed bug where queryState=false caused error.

### DIFF
--- a/src/widgets/button.coffee
+++ b/src/widgets/button.coffee
@@ -64,7 +64,8 @@
             @options.editable.execute @options.command, @options.commandValue
           else
             @options.editable.execute @options.command
-          queryState()
+          if typeof queryState is 'function'
+            queryState()
           return false
 
       return unless @options.queryState


### PR DESCRIPTION
In particular when queryState=false then we get an uncaught TypeError:
boolean is not a function.
