### PR TITLE
Show the toolbar on clicking the element

### DIFF
--- a/src/toolbar/contextual.coffee
+++ b/src/toolbar/contextual.coffee
@@ -88,7 +88,8 @@
       # show the toolbar when clicking the element
       @element.on 'click', (event, data) =>
         position = {}
-        position.top = event.clientY
+        scrollTop = $('window').scrollTop()
+        position.top = event.clientY + scrollTop
         position.left = event.clientX
         @_updatePosition(position, null)
         if @toolbar.html() != ''


### PR DESCRIPTION
Simple patch, Please review it if there is a more proper way.

When I click an editable element, I expect the toolbar to appear.

It's not obvious that you have these plugin options (bold, italic, etc..) when you need to select it first.
