### PR TITLE
Fixed a documentation mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Hallo provides some events that are useful for integration. You can use [jQuery 
 ## Plugins
 
 * halloformat - Adds Bold, Italic, StrikeThrough and Underline support to the toolbar. (Enable/Disable with options: "formattings": {"bold": true, "italic": true, "strikethrough": true, "underline": false})
-* halloheadings - Adds support for H1, H2, H3. You can pass a headings option key "headers" with an array of header sizes (i.e. headers: [1,2,5,6])
+* halloheadings - Adds support for H1, H2, H3. You can pass a headings option key to specify what is going to be displayed (e.g. "formatBlocks":["p", "h2","h3"])
 * hallojustify - Adds align left, center, right support
 * hallolists - Adds support for ordered and unordered lists (Pick with options: "lists": {"ordered": false, "unordered": true})
 * halloreundo - Adds support for undo and redo


### PR DESCRIPTION
Documentation was outdated for using the headings plugin. In order to customize options you now need to pass "formatBlocks" instead of "headers"