### PR TITLE
Adding support for the most recent version of Font Awesome.

### DIFF
--- a/src/plugins/annotate.coffee
+++ b/src/plugins/annotate.coffee
@@ -41,7 +41,7 @@
       buttonHolder = jQuery "<span class=\"#{@widgetName}\"></span>"
       @button = buttonHolder.hallobutton
         label: 'Annotate'
-        icon: 'icon-tags'
+        icon: 'fa-tags'
         editable: @options.editable
         command: null
         uuid: @options.uuid

--- a/src/plugins/block.coffee
+++ b/src/plugins/block.coffee
@@ -79,7 +79,7 @@
         uuid: @options.uuid
         editable: @options.editable
         label: 'block'
-        icon: 'icon-text-height'
+        icon: 'fa-text-height'
         target: target
         cssClass: @options.buttonCssClass
       buttonElement

--- a/src/plugins/html.coffee
+++ b/src/plugins/html.coffee
@@ -42,7 +42,7 @@
       $buttonHolder = jQuery '<span>'
       $buttonHolder.hallobutton
         label: @texts.title
-        icon: 'icon-list-alt'
+        icon: 'fa-list-alt'
         editable: @options.editable
         command: null
         queryState: false

--- a/src/plugins/image.coffee
+++ b/src/plugins/image.coffee
@@ -104,7 +104,7 @@
       buttonHolder = jQuery '<span></span>'
       buttonHolder.hallobutton
         label: 'Images'
-        icon: 'icon-picture'
+        icon: 'fa-picture-o'
         editable: @options.editable
         command: null
         queryState: false

--- a/src/plugins/image_insert_edit.coffee
+++ b/src/plugins/image_insert_edit.coffee
@@ -72,7 +72,7 @@
       $buttonHolder = jQuery '<span>'
       $buttonHolder.hallobutton
         label: @texts.title_insert
-        icon: 'icon-picture'
+        icon: 'fa-picture-o'
         editable: @options.editable
         command: null
         queryState: false

--- a/src/plugins/indicator.coffee
+++ b/src/plugins/indicator.coffee
@@ -14,7 +14,7 @@
     populateToolbar: ->
 
     buildIndicator: ->
-      editButton = jQuery '<div><i class="icon-edit"></i> Edit</div>'
+      editButton = jQuery '<div><i class="fa fa-edit"></i> Edit</div>'
       editButton.addClass @options.className
       do editButton.hide
 

--- a/src/plugins/justify.coffee
+++ b/src/plugins/justify.coffee
@@ -18,7 +18,7 @@
           editable: @options.editable
           label: alignment
           command: "justify#{alignment}"
-          icon: "icon-align-#{alignment.toLowerCase()}"
+          icon: "fa-align-#{alignment.toLowerCase()}"
           cssClass: @options.buttonCssClass
         buttonset.append buttonElement
       buttonize "Left"

--- a/src/plugins/link.coffee
+++ b/src/plugins/link.coffee
@@ -77,7 +77,7 @@
         buttonHolder = jQuery '<span></span>'
         buttonHolder.hallobutton
           label: 'Link'
-          icon: 'icon-link'
+          icon: 'fa fa-link'
           editable: @options.editable
           command: null
           queryState: false

--- a/src/plugins/lists.coffee
+++ b/src/plugins/lists.coffee
@@ -21,7 +21,7 @@
           editable: @options.editable
           label: label
           command: "insert#{type}List"
-          icon: "icon-list-#{label.toLowerCase()}"
+          icon: "fa-list-#{label.toLowerCase()}"
           cssClass: @options.buttonCssClass
         buttonset.append buttonElement
 

--- a/src/plugins/reundo.coffee
+++ b/src/plugins/reundo.coffee
@@ -17,7 +17,7 @@
           uuid: @options.uuid
           editable: @options.editable
           label: label
-          icon: if cmd is 'undo' then 'icon-undo' else 'icon-repeat'
+          icon: if cmd is 'undo' then 'fa-undo' else 'fa-repeat'
           command: cmd
           queryState: false
           cssClass: @options.buttonCssClass

--- a/src/widgets/button.coffee
+++ b/src/widgets/button.coffee
@@ -19,8 +19,8 @@
     _create: ->
       # By default the icon is icon-command, but this doesn't
       # always match with
-      # <http://fortawesome.github.com/Font-Awesome/#base-icons>
-      @options.icon ?= "icon-#{@options.label.toLowerCase()}"
+      # <http://fortawesome.github.io/Font-Awesome/icons/>
+      @options.icon ?= "fa-#{@options.label.toLowerCase()}"
 
       id = "#{@options.uuid}-#{@options.label}"
       opts = @options
@@ -109,7 +109,7 @@
       jQuery "<button id=\"#{id}\"
         class=\"#{classes.join(' ')}\" title=\"#{label}\">
           <span class=\"ui-button-text\">
-            <i class=\"#{icon}\"></i>
+            <i class=\"fa #{icon}\"></i>
           </span>
         </button>"
 

--- a/src/widgets/dropdownbutton.coffee
+++ b/src/widgets/dropdownbutton.coffee
@@ -14,7 +14,7 @@
       cssClass: null
 
     _create: ->
-      @options.icon ?= "icon-#{@options.label.toLowerCase()}"
+      @options.icon ?= "fa-#{@options.label.toLowerCase()}"
 
     _init: ->
       target = jQuery @options.target
@@ -67,7 +67,7 @@
       ]
       buttonEl = jQuery "<button id=\"#{id}\"
        class=\"#{classes.join(' ')}\" title=\"#{@options.label}\">
-       <span class=\"ui-button-text\"><i class=\"#{@options.icon}\"></i></span>
+       <span class=\"ui-button-text\"><i class=\"fa #{@options.icon}\"></i></span>
        </button>"
       buttonEl.addClass @options.cssClass if @options.cssClass
       buttonEl


### PR DESCRIPTION
As far as I can tell, Hallo does not currently work with Font Awesome 4.0, which changed its syntax. (As detailed here: https://github.com/FortAwesome/Font-Awesome/wiki/Upgrading-from-3.2.1-to-4)

I've gone through and updated the code wherever I saw the old syntax. I think I caught everything, but if not, it should be obvious.