### PR TITLE
Wait for the paste event to complete before trying to read the results

### DIFF
--- a/src/hallo.coffee
+++ b/src/hallo.coffee
@@ -339,7 +339,10 @@ http://hallojs.org
 
     _checkModified: (event) ->
       widget = event.data
-      widget.setModified() if widget.isModified()
+      # Wait for the paste event to complete before trying to read the results
+      setTimeout ->
+        widget.setModified() if widget.isModified()
+      , 0
 
     _keys: (event) ->
       widget = event.data


### PR DESCRIPTION
Hi, I ran into a problem with Hallo with users who use the GUI to paste text, rather than using ⌘V like a regular human being.  The paste event occurs before the text is actually pasted in, so editor doesn't yet contain the pasted text when checkModified occurs.  It happens to work for ⌘V because you also get a keyup event immediately afterward.

How about delaying the checkModified function like so?
