### PR TITLE
Fix  active indicator in examples/image.css

### DIFF
--- a/examples/image.css
+++ b/examples/image.css
@@ -74,7 +74,7 @@
     margin-left: 50px;
     width: 18px;
     height: 8px;
-    display: relative;
+    position: relative;
     background: url('images/arrow.png');
 }
 


### PR DESCRIPTION
Fixed invalid CSS property for active indicator.